### PR TITLE
Adding Close method to FirmataClient

### DIFF
--- a/client.go
+++ b/client.go
@@ -97,7 +97,7 @@ func NewClient(dev string, baud int) (client *FirmataClient, err error) {
 // Close the serial connection to properly clean up after ourselves
 // Usage: defer client.Close()
 func (c *FirmataClient) Close() {
-  conn.Close()
+  (*c.conn).Close()
 }
 
 // Sets the Pin mode (input, output, etc.) for the Arduino pin


### PR DESCRIPTION
It's a good idea to be able to close the serial port when we are done with it.  This allows us to attach a new instance of the FirmataClient to the same serial port if we need to.
