### PR TITLE
go-firmata package update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,52 @@
-go-firmata
-==========
+# go-firmata
+A Golang wrapper for [Firmata](https://www.arduino.cc/en/reference/firmata) on [Arduino](https://www.arduino.cc/) 
 
-Arduino Firmata client for golang
+[![GoDoc](http://godoc.org/github.com/kraman/go-firmata?status.svg)](http://godoc.org/github.com/kraman/go-firmata)
+
+## Installation
+
+```bash
+	go get github.com/kraman/go-firmata
+```
+
+## Usage
+
+```go
+package main
+
+import (
+	"github.com/kraman/go-firmata"
+	"time"
+)
+
+var led uint8 = 13
+
+func main() {
+	arduino, err := firmata.NewClient("COM1", 57600)
+	if err != nil {
+		panic(err)
+	}
+
+	// arduino.Verbose = true
+
+	myDelay := time.Millisecond * 250
+
+	// Set led pin as output
+	arduino.SetPinMode(led, firmata.Output)
+
+	// Blink led 10 times
+	for x := 0; x < 10; x++ {
+		
+		// Turn ON led
+		arduino.DigitalWrite(led, true)
+		arduino.Delay(myDelay)
+		
+		// Turn OFF led
+		arduino.DigitalWrite(led, false)
+		arduino.Delay(myDelay)
+
+	}
+	arduino.Close()
+}
+
+```

--- a/client.go
+++ b/client.go
@@ -15,197 +15,208 @@
 package firmata
 
 import (
-  "code.google.com/p/log4go"
-  "github.com/tarm/goserial"
-
-  "fmt"
-  "io"
-  "time"
+	"fmt"
+	"github.com/tarm/serial"
+	"io"
+	"log"
+	"os"
+	"time"
 )
 
 // Arduino Firmata client for golang
 type FirmataClient struct {
-  serialDev string
-  baud      int
-  conn      *io.ReadWriteCloser
-  Log       *log4go.Logger
+	serialDev string
+	baud      int
+	conn      *io.ReadWriteCloser
+	Log       *log.Logger
 
-  protocolVersion []byte
-  firmwareVersion []int
-  firmwareName    string
+	protocolVersion []byte
+	firmwareVersion []int
+	firmwareName    string
 
-  ready             bool
-  analogMappingDone bool
-  capabilityDone    bool
+	ready             bool
+	analogMappingDone bool
+	capabilityDone    bool
 
-  digitalPinState [8]byte
+	digitalPinState [8]byte
 
-  analogPinsChannelMap map[int]byte
-  analogChannelPinsMap map[byte]int
-  pinModes             []map[PinMode]interface{}
+	analogPinsChannelMap map[int]byte
+	analogChannelPinsMap map[byte]int
+	pinModes             []map[PinMode]interface{}
 
-  valueChan  chan FirmataValue
-  serialChan chan string
-  spiChan    chan []byte
+	valueChan  chan FirmataValue
+	serialChan chan string
+	spiChan    chan []byte
+
+	Verbose bool
 }
 
 // Creates a new FirmataClient object and connects to the Arduino board
 // over specified serial port. This function blocks till a connection is
 // succesfullt established and pin mappings are retrieved.
 func NewClient(dev string, baud int) (client *FirmataClient, err error) {
-  var conn io.ReadWriteCloser
+	var conn io.ReadWriteCloser
 
-  c := &serial.Config{Name: dev, Baud: baud}
-  conn, err = serial.OpenPort(c)
-  if err != nil {
-    client.Log.Critical(err)
-    return
-  }
+	c := &serial.Config{Name: dev, Baud: baud}
+	conn, err = serial.OpenPort(c)
+	if err != nil {
+		return nil, err
+	}
 
-  logger := make(log4go.Logger) 
-  logger.AddFilter("stdout", log4go.INFO, log4go.NewConsoleLogWriter())
-  client = &FirmataClient{
-    serialDev: dev,
-    baud:      baud,
-    conn:      &conn,
-    Log:       &logger,
-  }
-  go client.replyReader()
+	client = &FirmataClient{
+		serialDev: dev,
+		baud:      baud,
+		conn:      &conn,
+		Log:       log.New(os.Stdout, "[go-firmata] ", log.Ltime),
+	}
+	go client.replyReader()
 
-  conn.Write([]byte{byte(SystemReset)})
-  t := time.NewTicker(time.Second)
+	conn.Write([]byte{byte(SystemReset)})
+	t := time.NewTicker(time.Second)
 
-  for !(client.ready && client.analogMappingDone && client.capabilityDone) {
-    select {
-    case <-t.C:
-      //no-op
-    case <-time.After(time.Second * 15):
-      client.Log.Critical("No response in 30 seconds. Resetting arduino")
-      conn.Write([]byte{byte(SystemReset)})
-    case <-time.After(time.Second * 30):
-      client.Log.Critical("Unable to initialize connection")
-      conn.Close()
-      client = nil
-    }
-  }
+	for !(client.ready && client.analogMappingDone && client.capabilityDone) {
+		select {
+		case <-t.C:
+			//no-op
+		case <-time.After(time.Second * 15):
+			client.Log.Print("No response in 30 seconds. Resetting arduino")
+			conn.Write([]byte{byte(SystemReset)})
+		case <-time.After(time.Second * 30):
+			client.Log.Print("Unable to initialize connection")
+			conn.Close()
+			client = nil
+		}
+	}
 
-  client.Log.Info("Client ready to use")
+	client.Log.Print("Client ready to use")
 
-  return
+	return
+}
+
+// Close the serial connection to properly clean up after ourselves
+// Usage: defer client.Close()
+func (c *FirmataClient) Delay(duration time.Duration) {
+	time.Sleep(duration)
 }
 
 // Close the serial connection to properly clean up after ourselves
 // Usage: defer client.Close()
 func (c *FirmataClient) Close() {
-  (*c.conn).Close()
+	(*c.conn).Close()
 }
 
 // Sets the Pin mode (input, output, etc.) for the Arduino pin
-func (c *FirmataClient) SetPinMode(pin byte, mode PinMode) (err error) {
-  if c.pinModes[pin][mode] == nil {
-    err = fmt.Errorf("Pin mode %v not supported by pin %v", mode, pin)
-    return
-  }
-  cmd := []byte{byte(SetPinMode), (pin & 0x7F), byte(mode)}
-  err = c.sendCommand(cmd)
-  return
+func (c *FirmataClient) SetPinMode(pin uint8, mode PinMode) error {
+	if c.pinModes[pin][mode] == nil {
+		return fmt.Errorf("Pin mode %v not supported by pin %v", mode, pin)
+	}
+	cmd := []byte{byte(SetPinMode), (pin & 0x7F), byte(mode)}
+	if err := c.sendCommand(cmd); err != nil {
+		return err
+	}
+	c.Log.Printf("SetPinMode: pin %d -> %s\r\n", pin, mode)
+	return nil
 }
 
 // Specified if a digital Pin should be watched for input.
 // Values will be streamed back over a channel which can be retrieved by the GetValues() call
 func (c *FirmataClient) EnableDigitalInput(pin uint, val bool) (err error) {
-  if pin < 0 || pin > uint(len(c.pinModes)) {
-    err = fmt.Errorf("Invalid pin number %v\n", pin)
-    return
-  }
-  port := (pin / 8) & 0x7F
-  pin = pin % 8
+	if pin < 0 || pin > uint(len(c.pinModes)) {
+		err = fmt.Errorf("Invalid pin number %v\n", pin)
+		return
+	}
+	port := (pin / 8) & 0x7F
+	pin = pin % 8
 
-  if val {
-    cmd := []byte{byte(EnableDigitalInput) | byte(port), 0x01}
-    err = c.sendCommand(cmd)
-  } else {
-    cmd := []byte{byte(EnableDigitalInput) | byte(port), 0x00}
-    err = c.sendCommand(cmd)
-  }
+	if val {
+		cmd := []byte{byte(EnableDigitalInput) | byte(port), 0x01}
+		err = c.sendCommand(cmd)
+	} else {
+		cmd := []byte{byte(EnableDigitalInput) | byte(port), 0x00}
+		err = c.sendCommand(cmd)
+	}
 
-  return
+	return
 }
 
 // Set the value of a digital pin
-func (c *FirmataClient) DigitalWrite(pin uint, val bool) (err error) {
-  if pin < 0 || pin > uint(len(c.pinModes)) && c.pinModes[pin][Output] != nil {
-    err = fmt.Errorf("Invalid pin number %v\n", pin)
-    return
-  }
-  port := (pin / 8) & 0x7F
-  portData := &c.digitalPinState[port]
-  pin = pin % 8
-
-  if val {
-    (*portData) = (*portData) | (1 << pin)
-  } else {
-    (*portData) = (*portData) & ^(1 << pin)
-  }
-  data := to7Bit(*(portData))
-  cmd := []byte{byte(DigitalMessage) | byte(port), data[0], data[1]}
-  err = c.sendCommand(cmd)
-  return
+func (c *FirmataClient) DigitalWrite(pin uint8, val bool) error {
+	if pin < 0 || pin > uint8(len(c.pinModes)) && c.pinModes[pin][Output] != nil {
+		return fmt.Errorf("Invalid pin number %v\n", pin)
+	}
+	port := (pin / 8) & 0x7F
+	portData := &c.digitalPinState[port]
+	pin = pin % 8
+	if val {
+		(*portData) = (*portData) | (1 << pin)
+	} else {
+		(*portData) = (*portData) & ^(1 << pin)
+	}
+	data := to7Bit(*(portData))
+	cmd := []byte{byte(DigitalMessage) | byte(port), data[0], data[1]}
+	if err := c.sendCommand(cmd); err != nil {
+		return err
+	}
+	c.Log.Printf("DigitalWrite: pin %d -> %t\r\n", pin, val)
+	return nil
 }
 
 // Specified if a analog Pin should be watched for input.
 // Values will be streamed back over a channel which can be retrieved by the GetValues() call
 func (c *FirmataClient) EnableAnalogInput(pin uint, val bool) (err error) {
-  if pin < 0 || pin > uint(len(c.pinModes)) && c.pinModes[pin][Analog] != nil {
-    err = fmt.Errorf("Invalid pin number %v\n", pin)
-    return
-  }
+	if pin < 0 || pin > uint(len(c.pinModes)) && c.pinModes[pin][Analog] != nil {
+		err = fmt.Errorf("Invalid pin number %v\n", pin)
+		return
+	}
 
-  ch := byte(c.analogPinsChannelMap[int(pin)])
-  c.Log.Debug("Enable analog inout on pin %v channel %v", pin, ch)
-  if val {
-    cmd := []byte{byte(EnableAnalogInput) | ch, 0x01}
-    err = c.sendCommand(cmd)
-  } else {
-    cmd := []byte{byte(EnableAnalogInput) | ch, 0x00}
-    err = c.sendCommand(cmd)
-  }
+	ch := byte(c.analogPinsChannelMap[int(pin)])
+	c.Log.Printf("Enable analog inout on pin %v channel %v", pin, ch)
+	if val {
+		cmd := []byte{byte(EnableAnalogInput) | ch, 0x01}
+		err = c.sendCommand(cmd)
+	} else {
+		cmd := []byte{byte(EnableAnalogInput) | ch, 0x00}
+		err = c.sendCommand(cmd)
+	}
 
-  return
+	return
 }
 
 // Set the value of a analog pin
 func (c *FirmataClient) AnalogWrite(pin uint, pinData byte) (err error) {
-  if pin < 0 || pin > uint(len(c.pinModes)) && c.pinModes[pin][Analog] != nil {
-    err = fmt.Errorf("Invalid pin number %v\n", pin)
-    return
-  }
+	if pin < 0 || pin > uint(len(c.pinModes)) && c.pinModes[pin][Analog] != nil {
+		err = fmt.Errorf("Invalid pin number %v\n", pin)
+		return
+	}
 
-  data := to7Bit(pinData)
-  cmd := []byte{byte(AnalogMessage) | byte(pin), data[0], data[1]}
-  err = c.sendCommand(cmd)
-  return
+	data := to7Bit(pinData)
+	cmd := []byte{byte(AnalogMessage) | byte(pin), data[0], data[1]}
+	err = c.sendCommand(cmd)
+	return
 }
 
 func (c *FirmataClient) sendCommand(cmd []byte) (err error) {
-  bStr := ""
-  for _, b := range cmd {
-    bStr = bStr + fmt.Sprintf(" %#2x", b)
-  }
-  c.Log.Trace("Command send%v\n", bStr)
+	bStr := ""
+	for _, b := range cmd {
+		bStr = bStr + fmt.Sprintf(" %#2x", b)
+	}
 
-  _, err = (*c.conn).Write(cmd)
-  return
+	if c.Verbose {
+		c.Log.Printf("Command send%v\n", bStr)
+	}
+
+	_, err = (*c.conn).Write(cmd)
+	return
 }
 
 // Sets the polling interval in milliseconds for analog pin samples
 func (c *FirmataClient) SetAnalogSamplingInterval(ms byte) (err error) {
-  data := to7Bit(ms)
-  err = c.sendSysEx(SamplingInterval, data[0], data[1])
-  return
+	data := to7Bit(ms)
+	err = c.sendSysEx(SamplingInterval, data[0], data[1])
+	return
 }
 
 // Get the channel to retrieve analog and digital pin values
 func (c *FirmataClient) GetValues() <-chan FirmataValue {
-  return c.valueChan
+	return c.valueChan
 }

--- a/constants.go
+++ b/constants.go
@@ -1,11 +1,11 @@
 // Copyright 2014 Krishna Raman
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -71,7 +71,7 @@ const (
 
 	SPIConfig SPISubCommand = 0x10
 	SPIComm   SPISubCommand = 0x20
-	
+
 	SPI_MODE0 = 0x00
 	SPI_MODE1 = 0x04
 	SPI_MODE2 = 0x08
@@ -96,21 +96,21 @@ const (
 func (m PinMode) String() string {
 	switch {
 	case m == Input:
-		return fmt.Sprintf("Input pin (0x%x)", byte(m))
+		return "INPUT"
 	case m == Output:
-		return fmt.Sprintf("Output pin (0x%x)", byte(m))
+		return "OUTPUT"
 	case m == Analog:
-		return fmt.Sprintf("Analog pin (0x%x)", byte(m))
+		return "ANALOG"
 	case m == PWM:
-		return fmt.Sprintf("PWM pin (0x%x)", byte(m))
+		return "PWM"
 	case m == Servo:
-		return fmt.Sprintf("Servo pin (0x%x)", byte(m))
+		return "SERVO"
 	case m == Shift:
-		return fmt.Sprintf("Shift pin (0x%x)", byte(m))
+		return "SHIFT"
 	case m == I2C:
-		return fmt.Sprintf("I2C pin (0x%x)", byte(m))
+		return "I2C"
 	}
-	return fmt.Sprintf("Unknown pin (0x%x)", byte(m))
+	return "UNKNOWN"
 }
 
 func (c FirmataCommand) String() string {

--- a/examples/main.go
+++ b/examples/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"github.com/argandas/go-firmata"
+	"time"
+)
+
+var led uint8 = 13
+
+func main() {
+	arduino, err := firmata.NewClient("COM24", 57600)
+	if err != nil {
+		panic(err)
+	}
+
+	// arduino.Verbose = true
+
+	myDelay := time.Millisecond * 250
+
+	arduino.SetPinMode(led, firmata.Output)
+	for x := 0; x < 10; x++ {
+		// Turn ON led
+		arduino.DigitalWrite(led, true)
+		arduino.Delay(myDelay)
+		// Turn OFF led
+		arduino.DigitalWrite(led, false)
+		arduino.Delay(myDelay)
+
+	}
+	arduino.Close()
+}

--- a/serial_ext.go
+++ b/serial_ext.go
@@ -1,11 +1,11 @@
 // Copyright 2014 Krishna Raman
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -45,6 +45,6 @@ func (c *FirmataClient) parseSerialResponse(data7bit []byte) {
 	select {
 	case c.serialChan <- string(data):
 	default:
-		c.Log.Critical("Serial data buffer overflow. No listener?")
+		c.Log.Print("Serial data buffer overflow. No listener?")
 	}
 }

--- a/spi_ext.go
+++ b/spi_ext.go
@@ -1,11 +1,11 @@
 // Copyright 2014 Krishna Raman
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,14 +40,14 @@ func (c *FirmataClient) SPIReadWrite(csPin byte, data []byte) (dataOut []byte, e
 	}
 
 	err = c.sendSysEx(SysExSPI, data7Bit...)
-	dataOut = <- c.spiChan
+	dataOut = <-c.spiChan
 	return
 }
 
 func (c *FirmataClient) parseSPIResponse(data7bit []byte) {
-	data := make([]byte,0)
+	data := make([]byte, 0)
 	for i, _ := range data7bit {
-		if i >=3 && i%2 != 0 {
+		if i >= 3 && i%2 != 0 {
 			data = append(data, from7Bit(data7bit[i], data7bit[i+1]))
 		}
 	}

--- a/sysex.go
+++ b/sysex.go
@@ -1,11 +1,11 @@
 // Copyright 2014 Krishna Raman
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,18 +23,24 @@ func (c *FirmataClient) parseSysEx(data []byte) {
 	var cmd SysExCommand
 
 	cmd = SysExCommand(data[0])
-  c.Log.Trace("Processing sysex %v\n", cmd)
+
+	if c.Verbose {
+		c.Log.Printf("Processing sysex %v\n", cmd)
+	}
+
 	data = data[1:]
-	
+
 	bStr := ""
 	for _, b := range data {
 		bStr = bStr + fmt.Sprintf(" %#2x", b)
 	}
-  c.Log.Trace("SysEx recv %v\n", bStr)
-	
+	if c.Verbose {
+		c.Log.Printf("SysEx recv %v\n", bStr)
+	}
+
 	switch {
 	case cmd == StringData:
-		c.Log.Info("String data: %v", string(data))
+		c.Log.Printf("String data: %v", string(data))
 	case cmd == CapabilityResponse:
 		dataBuf := bytes.NewBuffer(data)
 		c.pinModes = make([]map[PinMode]interface{}, 0)
@@ -55,7 +61,7 @@ func (c *FirmataClient) parseSysEx(data []byte) {
 			c.pinModes = append(c.pinModes, pinModes)
 			pin = pin + 1
 		}
-    c.Log.Debug("Total pins: %v\n", pin-1)
+		c.Log.Printf("Total pins: %v\n", pin-1)
 		c.capabilityDone = true
 	case cmd == AnalogMappingResponse:
 		c.analogPinsChannelMap = make(map[int]byte)
@@ -66,16 +72,16 @@ func (c *FirmataClient) parseSysEx(data []byte) {
 				c.analogChannelPinsMap[channel] = pin
 			}
 		}
-		c.Log.Trace("pin -> channel: %v\n", c.analogPinsChannelMap)
+		c.Log.Printf("pin -> channel: %v\n", c.analogPinsChannelMap)
 		c.analogMappingDone = true
 	case cmd == ReportFirmware:
 		c.firmwareVersion = make([]int, 2)
 		c.firmwareVersion[0] = int(data[0])
 		c.firmwareVersion[1] = int(data[1])
 		data = data[2:]
-		c.Log.Trace("in %v", data[2:])
+		c.Log.Printf("in %v", data[2:])
 		c.firmwareName = multibyteString(data)
-		c.Log.Info("Firmware: %v [%v.%v]", c.firmwareName, c.firmwareVersion[0], c.firmwareVersion[1])
+		c.Log.Printf("Firmware: %v [%v.%v]", c.firmwareName, c.firmwareVersion[0], c.firmwareVersion[1])
 		c.ready = true
 		c.sendSysEx(AnalogMappingQuery)
 		c.sendSysEx(CapabilityQuery)
@@ -84,7 +90,7 @@ func (c *FirmataClient) parseSysEx(data []byte) {
 	case cmd == SysExSPI:
 		c.parseSPIResponse(data)
 	default:
-		c.Log.Debug("Discarding unexpected SysEx command %v", cmd)
+		c.Log.Printf("Discarding unexpected SysEx command %v", cmd)
 	}
 }
 
@@ -100,7 +106,7 @@ func (c *FirmataClient) sendSysEx(cmd SysExCommand, data ...byte) (err error) {
 	for _, b := range b.Bytes() {
 		bStr = bStr + fmt.Sprintf(" %#2x", b)
 	}
-	c.Log.Trace("SysEx send %v\n", bStr)
+	c.Log.Printf("SysEx send %v\n", bStr)
 
 	_, err = b.WriteTo(*(c.conn))
 	return

--- a/util.go
+++ b/util.go
@@ -1,11 +1,11 @@
 // Copyright 2014 Krishna Raman
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
- log4go removed, now using Go's log package 
  - this eliminates the dependance of hg (Mercurial)
  - reduces the need of external packages
- tarm/goserial package changed for tarm/serial (Updated version)
- go fmt applied
- Stringers for PinMode modified
- Added verbose control capability to avoid printing all the commands on-screen
- Delay method added 
- Standarized data type for pinMode and digitalWrite (uint8)
- Usage example added
- Readme updated

This work great! :P
